### PR TITLE
Add support to run from helm-find-files.

### DIFF
--- a/helm-git.el
+++ b/helm-git.el
@@ -69,6 +69,23 @@
   (magit-git-lines "ls-files" "--full-name"
                    "--" (helm-git-file-name-localname (helm-git-root-dir))))
 
+(defun helm-ff-git-find-files (candidate)
+  (let ((default-directory (file-name-as-directory
+                            (if (file-directory-p candidate)
+                                (expand-file-name candidate)
+                                (file-name-directory candidate))))) 
+    (helm-run-after-quit
+     #'(lambda (d)
+         (let ((default-directory d))
+           (helm-git-find-files)))
+     default-directory)))
+
+(when (require 'helm-files)
+  (helm-add-action-to-source
+   "List git files"
+   'helm-ff-git-find-files helm-c-source-find-files
+   helm-git-ff-action-index))
+
 (defvar helm-c-source-git-files
   `((name . "Git files list")
     (init . (lambda ()

--- a/helm-git.el
+++ b/helm-git.el
@@ -69,6 +69,10 @@
   (magit-git-lines "ls-files" "--full-name"
                    "--" (helm-git-file-name-localname (helm-git-root-dir))))
 
+;; [NOTE] When value is changed need to restart emacs.
+(defvar helm-git-ff-action-index 4
+  "Add list git files action in `helm-c-source-find-files' at this index.")
+
 (defun helm-ff-git-find-files (candidate)
   (let ((default-directory (file-name-as-directory
                             (if (file-directory-p candidate)


### PR DESCRIPTION
Hi, some code to launch listing of git files from helm-find-files.
This allow to list file in other directories than default-directory.
The variable `helm-git-ff-action-index` allow to put the action somewhere else in action list.
